### PR TITLE
Remove compile time warnings

### DIFF
--- a/src/core/src/enclave_sgx.rs
+++ b/src/core/src/enclave_sgx.rs
@@ -24,7 +24,6 @@ use std::env;
 use std::os::raw::c_char;
 use std::str;
 use std::vec::Vec;
-use num::ToPrimitive;
 use std::string::String;
 use poet2_util;
 use std::path::Path;
@@ -162,7 +161,7 @@ impl EnclaveConfig {
                                         ser_wait_cert: 0 as *mut c_char,
                                         ser_wait_cert_sign: 0 as *mut c_char};
 
-    	let ret = ffi::finalize_wait_cert(&mut eid, &mut wait_cert_info,
+    	ffi::finalize_wait_cert(&mut eid, &mut wait_cert_info,
                                           &in_wait_cert, &in_prev_block_id,
                                           &in_prev_wait_cert_sig,
                                           &in_block_summary, &in_wait_time)
@@ -177,7 +176,7 @@ impl EnclaveConfig {
         info!("wait certificate generated is {:?}", wait_cert);
 
         //release wait certificate
-        let status = ffi::release_wait_certificate(&mut eid, &mut wait_cert_info)
+        ffi::release_wait_certificate(&mut eid, &mut wait_cert_info)
                                 .expect("Failed to release wait certificate");
 
     	(wait_cert, wait_cert_sign)
@@ -192,7 +191,7 @@ impl EnclaveConfig {
     {
         let mut eid:r_sgx_enclave_id_t =  eid;
         let mut verify_wait_cert_status: bool = false;
-        let ret = ffi::verify_wait_certificate(&mut eid, &wait_cert.as_str(),
+        ffi::verify_wait_certificate(&mut eid, &wait_cert.as_str(),
                             &wait_cert_sign.as_str(), &poet_pub_key.as_str(),
                             &mut verify_wait_cert_status)
                             .expect("Failed to verify wait certificate");
@@ -203,7 +202,7 @@ impl EnclaveConfig {
         let mut eid:r_sgx_enclave_id_t = self.enclave_id;
         let mut epid_info:r_sgx_epid_group_t = r_sgx_epid_group_t {
                                                     epid : 0 as *mut c_char};
-        let ret = ffi::get_epid_group(&mut eid, &mut epid_info)
+        ffi::get_epid_group(&mut eid, &mut epid_info)
                                       .expect("Failed to get EPID group");
 
         let epid = ffi::create_string_from_char_ptr(epid_info.epid);
@@ -214,7 +213,7 @@ impl EnclaveConfig {
     pub fn check_if_sgx_simulator(&mut self) -> bool {
         let mut eid:r_sgx_enclave_id_t = self.enclave_id;
         let mut sgx_simulator: bool = false;
-        let ret = ffi::is_sgx_simulator(&mut eid, &mut sgx_simulator)
+        ffi::is_sgx_simulator(&mut eid, &mut sgx_simulator)
                                         .expect("Failed to check SGX simulator");
         debug!("is_sgx_simulator ? {:?}", if sgx_simulator {"Yes"} else {"No"});
         sgx_simulator
@@ -222,14 +221,14 @@ impl EnclaveConfig {
 
     pub fn set_sig_revocation_list(&mut self, sig_rev_list: &String) {
         let mut eid:r_sgx_enclave_id_t = self.enclave_id;
-        let ret = ffi::set_sig_revocation_list(&mut eid, 
+        ffi::set_sig_revocation_list(&mut eid, 
                                       &sig_rev_list.as_str())
                                 .expect("Failed to set sig revocation list");
         debug!("Signature revocation list has been updated");
     }
 
     pub fn get_signup_parameters(&mut self) ->(String, String) {
-        let mut signup_data:r_sgx_signup_info_t = self.signup_info;
+        let signup_data:r_sgx_signup_info_t = self.signup_info;
         let poet_pub_key = ffi::create_string_from_char_ptr(
                                   signup_data.poet_public_key as *mut c_char);
         let enclave_quote = ffi::create_string_from_char_ptr(

--- a/src/core/src/engine/check_consensus.rs
+++ b/src/core/src/engine/check_consensus.rs
@@ -19,25 +19,10 @@ extern crate sawtooth_sdk;
 extern crate log;
 extern crate log4rs;
  
-use sawtooth_sdk::consensus::{engine::*, service::Service};
+use sawtooth_sdk::consensus::{engine::*};
 use service::Poet2Service;
-use std::sync::mpsc::{Receiver, RecvTimeoutError};
-use std::time;
-use std::str::FromStr;
 use std::cmp;
-use serde_json;
-use std::time::Duration;
-use std::time::Instant;
-use std::collections::HashMap;
-use enclave_sgx::*;
-use engine::consensus_state::*;
-use engine::consensus_state_store::ConsensusStateStore;
 use poet2_util;
-use database::config;
-use database::lmdb;
-use database::{DatabaseError, CliError};
-use settings_view::Poet2SettingsView;
-use engine::fork_resolver;
 
 const DEFAULT_BLOCK_CLAIM_LIMIT:i32 = 250;
 
@@ -109,9 +94,9 @@ fn verify_wait_certificate(
 fn validtor_has_claimed_block_limit( service: &mut Poet2Service ) -> bool {
 
     let mut block_claim_limit = DEFAULT_BLOCK_CLAIM_LIMIT;
-    let mut key_block_claim_count=9;
-    let mut    poet_public_key="abcd";
-    let mut    validator_info_signup_info_poet_public_key="abcd";
+    let key_block_claim_count=9;
+    let poet_public_key="abcd";
+    let validator_info_signup_info_poet_public_key="abcd";
     //  let mut key_block_claim_limit = poet_settings_view.key_block_claim_limit ;     //key
     // need to use get_settings from service
     let key_block_claim_limit = service.get_setting_from_head(
@@ -174,42 +159,6 @@ fn validator_is_claiming_too_early( block: &Block, service: &mut Poet2Service )-
     debug!("Passed c-test");
     return false;
 
-}
-
-fn create_context() -> Result<lmdb::LmdbContext, CliError> {
-    let path_config = config::get_path_config();
-    let statestore_path = &path_config.data_dir.join(config::get_filename());
-
-    lmdb::LmdbContext::new(statestore_path, 1, None)
-        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))
-}
-
-fn open_statestore(ctx: &lmdb::LmdbContext) -> Result<ConsensusStateStore, CliError> {
-    let statestore_db = lmdb::LmdbDatabase::new(
-        ctx,
-        &["index_consensus_state"],
-    ).map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
-
-    Ok(ConsensusStateStore::new(statestore_db))
-}
-
-pub enum ResponseMessage {
-    Ack,
-    Published,
-    Received,
-}
-
-impl FromStr for ResponseMessage {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ack" => Ok(ResponseMessage::Ack),
-            "published" => Ok(ResponseMessage::Published),
-            "received" => Ok(ResponseMessage::Received),
-            _ => Err("Invalid message type"),
-        }
-    }
 }
 
 //z-test

--- a/src/core/src/engine/consensus_state.rs
+++ b/src/core/src/engine/consensus_state.rs
@@ -21,8 +21,6 @@ use service::Poet2Service;
 use enclave_sgx::WaitCertificate;
 use std::collections::VecDeque;
 use std::collections::HashMap;
-#[macro_use]
-use serde_derive;
 use serde_json;
 
 /*
@@ -140,15 +138,13 @@ struct Entry{
 
 impl ConsensusState{
 
-    const MINIMUM_WAIT_TIME: f64 =  1.0; 
     pub fn consensus_state_for_block_id(&mut self, block_id: BlockId, svc: &mut Poet2Service) -> Option<ConsensusState>{
        let mut previous_wait_certificate: Option<WaitCertificate> = None;
        let mut consensus_state: Option<ConsensusState> = None;
-       let mut wait_certificate : Option<WaitCertificate> = None;
        let mut blocks: Vec<Entry> = Vec::new();
        let mut current_id = block_id;
        loop{
-         let mut block_ = svc.get_block(&current_id);
+         let block_ = svc.get_block(&current_id);
          let block: Block;
          if block_.is_ok(){
            block = block_.unwrap();
@@ -160,9 +156,9 @@ impl ConsensusState{
          if consensus_state != None{
            break
          }*/
-         let mut payload_vec = block.payload;
-         let mut payload_str  = String::from_utf8(payload_vec).expect("Found Invalid UTF-8"); 
-         let mut wait_certificate = Some(serde_json::from_str(&payload_str).unwrap());
+         let payload_vec = block.payload;
+         let payload_str  = String::from_utf8(payload_vec).expect("Found Invalid UTF-8"); 
+         let wait_certificate = Some(serde_json::from_str(&payload_str).unwrap());
          if  wait_certificate.is_some() {
            //TODO
          }
@@ -195,9 +191,9 @@ impl ConsensusState{
       while self.population_samples.len() > poet_settings_view.population_estimate_sample_size{
         self.population_samples.pop_front();
       }
-       let mut validator_state = self.get_validator_state(validator_info.clone());
-       let mut total_block_claim_count = validator_state.total_block_claim_count + 1;
-       let mut key_block_claim_count = if validator_info.poet_public_key == validator_state.poet_public_key {
+       let validator_state = self.get_validator_state(validator_info.clone());
+       let total_block_claim_count = validator_state.total_block_claim_count + 1;
+       let key_block_claim_count = if validator_info.poet_public_key == validator_state.poet_public_key {
                                                 validator_state.key_block_claim_count + 1
                                        } 
                                        else{
@@ -212,8 +208,8 @@ impl ConsensusState{
    pub fn get_validator_state(&mut self,  validator_info: ValidatorInfo) -> Box<ValidatorState>{
      let peerid_vec = Vec::from(validator_info.clone().id);
      let peerid_str = String::from_utf8(peerid_vec).expect("Found Invalid UTF-8");
-     let mut validator_state = self.validators.get(&peerid_str);
-     let mut val_state = ValidatorState{ key_block_claim_count: 0, poet_public_key: validator_info.clone().poet_public_key, total_block_claim_count: 0};
+     let validator_state = self.validators.get(&peerid_str);
+     let val_state = ValidatorState{ key_block_claim_count: 0, poet_public_key: validator_info.clone().poet_public_key, total_block_claim_count: 0};
      if validator_state.is_none(){
       return Box::new(val_state); 
      }

--- a/src/core/src/engine/consensus_state_store.rs
+++ b/src/core/src/engine/consensus_state_store.rs
@@ -15,12 +15,10 @@
  * ------------------------------------------------------------------------------
  */
 
-use protobuf;
 use engine::consensus_state::ConsensusState;
 use sawtooth_sdk::consensus::engine::BlockId;
-use database::lmdb;
-use database::lmdb::{LmdbContext, LmdbDatabase};
-use database::{DatabaseError, CliError};
+use database::lmdb::LmdbDatabase;
+use database::DatabaseError;
 use bincode::{serialize, deserialize};
 use poet2_util;
 
@@ -85,6 +83,8 @@ mod tests {
     use database::config;
     use std::fs;
     use std::path::Path;
+    use database::lmdb;
+    use database::CliError;
 
     /// Asserts that there are COUNT many objects in DB.
     fn assert_database_db_count(count: usize, db: &LmdbDatabase) {

--- a/src/core/src/engine/mod.rs
+++ b/src/core/src/engine/mod.rs
@@ -21,9 +21,6 @@ pub mod consensus_state_store;
 pub mod consensus_state;
 pub mod fork_resolver;
  
-use std::cmp;
-use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::time::Duration;
 use std::time::Instant;
@@ -58,11 +55,11 @@ impl Engine for Poet2Engine {
         info!("Started PoET 2 Engine...");
 
         let validator_id = Vec::from(startup_state.local_peer_info.peer_id);
-        let mut chain_head = startup_state.chain_head;
+        let chain_head = startup_state.chain_head;
 
         let mut service = Poet2Service::new(service);
 
-        let mut lmdb_ctx = create_lmdb_context()
+        let lmdb_ctx = create_lmdb_context()
                            .expect("Failed to create context");
         let mut state_store = open_statestore(&lmdb_ctx)
                               .expect("Failed to create state store");
@@ -177,7 +174,7 @@ impl Engine for Poet2Engine {
                                                                  cur_chain_head,
                                                                  wait_time.as_secs());
 
-                let new_block_id = service.finalize_block(consensus.as_bytes().to_vec());
+                service.finalize_block(consensus.as_bytes().to_vec());
                 is_published_at_height = true;
             }
         }

--- a/src/core/src/main.rs
+++ b/src/core/src/main.rs
@@ -20,7 +20,6 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
@@ -48,7 +47,7 @@ use std::process;
 use log::LevelFilter;
 use log4rs::append::file::FileAppender;
 use log4rs::append::console::ConsoleAppender;
-use log4rs::config::{Appender, Config, Root, Logger};
+use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
 
 /*

--- a/src/core/src/poet2_util.rs
+++ b/src/core/src/poet2_util.rs
@@ -10,7 +10,7 @@ pub fn to_hex_string(bytes: &Vec<u8>) -> String {
 }
 
 pub fn blockid_to_hex_string(blockid: BlockId) -> String {
-    let mut blockid_vec = Vec::from(blockid);
+    let blockid_vec = Vec::from(blockid);
     to_hex_string(&blockid_vec)
 }
 

--- a/src/core/src/settings_view.rs
+++ b/src/core/src/settings_view.rs
@@ -16,7 +16,7 @@
  */
 
 use std::collections::HashMap;
-use sawtooth_sdk::consensus::{engine::BlockId, service::Service};
+use sawtooth_sdk::consensus::engine::BlockId;
 use service::Poet2Service;
 
 #[derive(Clone, Debug, Default)]
@@ -75,62 +75,62 @@ impl Poet2SettingsView {
         in_default_value
     }
 
-    fn block_claim_delay(&self) -> u64 {
+    pub fn block_claim_delay(&self) -> u64 {
         let default_block_claim_delay = 1_u64;
         self._get_config_value_as_u64(
               "sawtooth.consensus.poet2.block_claim_delay",
                                  default_block_claim_delay)
     }
 
-    fn initial_wait_time(&self) -> f64 {
+    pub fn initial_wait_time(&self) -> f64 {
         let default_initial_wait_time = 3000.0_f64;
         self._get_config_value_as_f64(
               "sawtooth.consensus.poet2.initial_wait_time",
                                  default_initial_wait_time)
     }
 
-    fn key_block_claim_limit(&self) -> u64 {
+    pub fn key_block_claim_limit(&self) -> u64 {
         let default_key_block_claim_limit = 250_u64;
         self._get_config_value_as_u64(
                "sawtooth.consensus.poet2.key_block_claim_limit",
                                  default_key_block_claim_limit)
     }
 
-    fn population_estimate_sample_size(&self) -> u64 {
+    pub fn population_estimate_sample_size(&self) -> u64 {
         let default_population_estimate_sample_size = 50_u64;
         self._get_config_value_as_u64(
                "sawtooth.consensus.poet2.population_estimate_sample_size",
                                  default_population_estimate_sample_size)
     }
 
-    fn registration_retry_delay(&self) -> u64 {
+    pub fn registration_retry_delay(&self) -> u64 {
         let default_registration_retry_delay = 10_u64;
         self._get_config_value_as_u64(
                "sawtooth.consensus.poet2.registration_retry_delay",
                                  default_registration_retry_delay)
     }
 
-    fn signup_commit_maximum_delay(&self) -> u64 {
+    pub fn signup_commit_maximum_delay(&self) -> u64 {
         let default_signup_commit_maximum_delay = 10_u64;
         self._get_config_value_as_u64(
                "sawtooth.consensus.poet2.signup_commit_maximum_delay",
                                  default_signup_commit_maximum_delay)
     }
 
-    fn target_wait_time(&self) -> f64 {
+    pub fn target_wait_time(&self) -> f64 {
         let default_target_wait_time = 20.0_f64;
         self._get_config_value_as_f64("sawtooth.consensus.poet2.target_wait_time",
                                  default_target_wait_time)
     }
 
-    fn z_test_maximum_win_deviation(&self) -> f64 {
+    pub fn z_test_maximum_win_deviation(&self) -> f64 {
         let default_z_test_maximum_win_deviation = 3.075_f64;
         self._get_config_value_as_f64(
                "sawtooth.consensus.poet2.z_test_maximum_win_deviation",
                                  default_z_test_maximum_win_deviation)
     }
 
-    fn z_test_minimum_win_count(&self) -> u64 {
+    pub fn z_test_minimum_win_count(&self) -> u64 {
         let default_z_test_minimum_win_count = 3_u64;
         self._get_config_value_as_u64(
                "sawtooth.consensus.poet2.z_test_minimum_win_count",


### PR DESCRIPTION
Reduce number of warnings at compile time. Few warnings
persist as stub codes are there(under development).

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>