### PR TITLE
Create debian for validator registry TP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ node ('master') {
             stage("Archive Build Artifacts") {
                 sh 'docker-compose -f copy-debs.yaml up'
                 sh 'docker-compose -f copy-debs.yaml down'
-                archiveArtifacts artifacts: 'sawtooth-poet*amd64.deb'
+                archiveArtifacts artifacts: '*_amd64.deb'
             }
         }
     }

--- a/copy-debs.yaml
+++ b/copy-debs.yaml
@@ -14,3 +14,14 @@ services:
       bash -c "
         cp /tmp/*.deb /build/debs
       "
+
+  poet-validator-registry-tp:
+    image: sawtooth-poet-validator-registry-tp:${ISOLATION_ID}
+    build:
+      context: .
+    volumes:
+      - .:/build/debs
+    command: |
+      bash -c "
+        cp /tmp/*.deb /build/debs
+      "

--- a/docker-compose-3-nodes.yaml
+++ b/docker-compose-3-nodes.yaml
@@ -317,7 +317,7 @@ services:
     depends_on:
       - validator-1
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-1:4004 && \
          tail -f /dev/null \
         \""
@@ -343,7 +343,7 @@ services:
     depends_on:
       - validator-2
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-2:4004 && \
          tail -f /dev/null \
         \""
@@ -369,7 +369,7 @@ services:
     depends_on:
       - validator-3
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-3:4004 && \
          tail -f /dev/null \
         \""

--- a/docker-compose-5-nodes.yaml
+++ b/docker-compose-5-nodes.yaml
@@ -494,7 +494,7 @@ services:
     depends_on:
       - validator-1
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-1:4004 && \
          tail -f /dev/null \
         \""
@@ -520,7 +520,7 @@ services:
     depends_on:
       - validator-2
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-2:4004 && \
          tail -f /dev/null \
         \""
@@ -546,7 +546,7 @@ services:
     depends_on:
       - validator-3
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-3:4004 && \
          tail -f /dev/null \
         \""
@@ -572,7 +572,7 @@ services:
     depends_on:
       - validator-4
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-4:4004 && \
          tail -f /dev/null \
         \""
@@ -598,7 +598,7 @@ services:
     depends_on:
       - validator-5
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-5:4004 && \
          tail -f /dev/null \
         \""

--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -13,3 +13,13 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
+
+  poet-validator-registry-tp:
+    image: sawtooth-poet-validator-registry-tp:${ISOLATION_ID}
+    build:
+      context: .
+      dockerfile: src/validator-registry-tp/Dockerfile-installed
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy

--- a/docker-compose-sgx-hw.yaml
+++ b/docker-compose-sgx-hw.yaml
@@ -155,7 +155,7 @@ services:
     depends_on:
       - validator-1
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-1:4004 && \
          tail -f /dev/null \
         \""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -150,7 +150,7 @@ services:
     depends_on:
       - validator-1
     entrypoint: "bash -c \"\
-        RUST_BACKTRACE=1 cargo run --bin validator_registry_tp -- -vv -C \
+        RUST_BACKTRACE=1 cargo run --bin validator-registry-tp -- -vv -C \
         tcp://validator-1:4004 && \
          tail -f /dev/null \
         \""

--- a/packaging/systemd/validator-registry-tp
+++ b/packaging/systemd/validator-registry-tp
@@ -1,0 +1,16 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+VAL_REG_TP_ARGS=-v -C tcp://localhost:4004

--- a/packaging/systemd/validator-registry-tp.service
+++ b/packaging/systemd/validator-registry-tp.service
@@ -1,0 +1,28 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+[Unit]
+Description=Sawtooth Validator Registry Transaction Processor
+After=network.target
+
+[Service]
+User=sawtooth
+Group=sawtooth
+EnvironmentFile=-/etc/default/validator-registry-tp
+ExecStart=/usr/bin/validator-registry-tp $VAL_REG_TP_ARGS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -38,7 +38,7 @@ bincode = "1.0.1"
 common = { path = "../common" }
 ias_client = { path = "../ias_client" }
 rust_sgxffi = { path = "../sgx/rust_sgxffi"}
-validator_registry_tp = { path = "../validator-registry-tp" }
+validator-registry-tp = { path = "../validator-registry-tp" }
 hyper = "0.12.11"
 tokio-core = "0.1.17"
 toml = "0.4.8"

--- a/src/validator-registry-tp/Cargo.toml
+++ b/src/validator-registry-tp/Cargo.toml
@@ -14,9 +14,19 @@
 # ------------------------------------------------------------------------------
 
 [package]
-name = "validator_registry_tp"
+name = "validator-registry-tp"
 version = "1.0.0"
 authors = ["Intel Corporation"]
+
+[package.metadata.deb]
+maintainer = "sawtooth"
+depends = "$auto"
+copyright = "Copyright 2018 Intel Corporation"
+assets = [
+    ["../../packaging/systemd/validator-registry-tp.service", "/lib/systemd/system/validator-registry-tp.service", "644"],
+    ["../../packaging/systemd/validator-registry-tp", "/etc/default/validator-registry-tp", "644"],
+    ["target/release/validator-registry-tp", "/usr/bin/validator-registry-tp", "755"],
+]
 
 [dependencies]
 sawtooth-sdk = { git = "https://github.com/hyperledger/sawtooth-core.git" }
@@ -48,7 +58,7 @@ test = true
 
 [[bin]]
 # The name of binary created, note ias_proxy is a binary
-name = "validator_registry_tp"
+name = "validator-registry-tp"
 
 # This field point where the binary can be built (place of main)
 path = "src/main.rs"

--- a/src/validator-registry-tp/Dockerfile-installed
+++ b/src/validator-registry-tp/Dockerfile-installed
@@ -1,0 +1,88 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# -------------=== validator registry tp deb build ===-------------
+FROM ubuntu:xenial as validator-reg-tp-builder
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q --allow-downgrades \
+    build-essential \
+    curl \
+    cmake \
+    libssl-dev \
+    gcc \
+    git \
+    libzmq3-dev \
+    openssl \
+    pkg-config \
+    python3 \
+    unzip \
+    clang \
+    libclang-dev \
+    libc6-dev \
+    libjson-c-dev \
+    libcrypto++-dev \
+    make \
+    python3-grpcio-tools=1.1.3-1 \
+    && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+  http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
+  https_proxy=$HTTPS_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+  http_proxy_host=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\1|');\
+  http_proxy_port=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\2|');\
+  mkdir -p $HOME/.cargo \
+  && echo "[http]" >> $HOME/.cargo/config \
+  && echo 'proxy = "'$http_proxy_host:$http_proxy_port'"' >> $HOME/.cargo/config \
+  && cat $HOME/.cargo/config; \
+ fi;
+
+# For Building Protobufs
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
+ && curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+ && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
+ && rm protoc-3.5.1-linux-x86_64.zip
+
+WORKDIR /tmp
+
+ENV PATH=$PATH:/protoc3/bin:/root/.cargo/bin
+RUN /root/.cargo/bin/cargo install cargo-deb
+
+COPY . /project/sawtooth-poet
+
+WORKDIR /project/sawtooth-poet/src/validator-registry-tp
+
+RUN bash -c "/root/.cargo/bin/cargo deb"
+
+# -------------=== validator registry tp docker build ===-------------
+FROM ubuntu:xenial
+
+COPY --from=validator-reg-tp-builder /project/sawtooth-poet/src/validator-registry-tp/target/debian/validator-registry*.deb /tmp
+
+RUN apt-get update \
+ && dpkg -i /tmp/validator-registry*.deb || true \
+ && apt-get -f -y install
+
+CMD validator-registry-tp

--- a/validator-tp-compose.yaml
+++ b/validator-tp-compose.yaml
@@ -32,6 +32,6 @@ services:
     entrypoint: "bash -c \"rm -rf /project/validator-registry-tp/bin &&\
 	mkdir -p ./bin/ &&\
 	cd /project/validator-registry-tp &&\ 
-	cargo build --release && cp ./target/release/validator_registry_tp ./bin/validator_registry_tp &&\
-	cargo run --bin validator_registry_tp -- -C tcp://localhost:4004 && tail -f /dev/null \""
+	cargo build --release && cp ./target/release/validator-registry-tp ./bin/validator-registry-tp &&\
+	cargo run --bin validator-registry-tp -- -C tcp://localhost:4004 && tail -f /dev/null \""
     stop_signal: SIGKILL


### PR DESCRIPTION
1.) Create debian for validator-registry-tp alongside sawtooth-poet
2.) Enable archiving at Jenkins
3.) Rename binary to validator-registry-tp instead of
    validator_registry_tp

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>