### PR TITLE
Add a docker-compose file for fixing rustfmt

### DIFF
--- a/common/src/lru_cache.rs
+++ b/common/src/lru_cache.rs
@@ -92,7 +92,7 @@ where
             None =>
             /* unexpected */
             {
-                return None
+                return None;
             }
         };
         Option::from(to_return)

--- a/docker/compose/fix-rustfmt.yaml
+++ b/docker/compose/fix-rustfmt.yaml
@@ -1,0 +1,102 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: '3.6'
+
+services:
+
+  fix-rustfmt-core:
+    build:
+      context: .
+      dockerfile: ../lint.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: lint:${ISOLATION_ID}
+    volumes:
+      - ../..:/project/sawtooth-poet
+    working_dir: "/project/sawtooth-poet/core"
+    command: cargo fmt
+
+  fix-rustfmt-sgxffi:
+    build:
+      context: .
+      dockerfile: ../lint.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: lint:${ISOLATION_ID}
+    volumes:
+      - ../..:/project/sawtooth-poet
+    working_dir: "/project/sawtooth-poet/sgx/rust_sgxffi"
+    command: cargo fmt
+
+  fix-rustfmt-common:
+    build:
+      context: .
+      dockerfile: ../lint.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: lint:${ISOLATION_ID}
+    volumes:
+      - ../..:/project/sawtooth-poet
+    working_dir: "/project/sawtooth-poet/common"
+    command: cargo fmt
+
+  fix-rustfmt-vrtp:
+    build:
+      context: .
+      dockerfile: ../lint.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: lint:${ISOLATION_ID}
+    volumes:
+      - ../..:/project/sawtooth-poet
+    working_dir: "/project/sawtooth-poet/validator-registry-tp"
+    command: cargo fmt
+
+  fix-rustfmt-ias-client:
+    build:
+      context: .
+      dockerfile: ../lint.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: lint:${ISOLATION_ID}
+    volumes:
+      - ../..:/project/sawtooth-poet
+    working_dir: "/project/sawtooth-poet/ias_client"
+    command: cargo fmt
+
+  fix-rustfmt-ias-proxy:
+    build:
+      context: .
+      dockerfile: ../lint.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: lint:${ISOLATION_ID}
+    volumes:
+      - ../..:/project/sawtooth-poet
+    working_dir: "/project/sawtooth-poet/ias_proxy"
+    command: cargo fmt


### PR DESCRIPTION
This file can be used to fix rustfmt issues, by default for all
sub-projects under sawtooth-poet will be fixed. If needed a
particular container name can be specified.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>